### PR TITLE
Fix typos in EDIO24 adl file

### DIFF
--- a/measCompApp/op/adl/EDIO24_module.adl
+++ b/measCompApp/op/adl/EDIO24_module.adl
@@ -1220,7 +1220,7 @@ composite {
 						height=30
 					}
 					control {
-						chan="$(P)$(Bd11"
+						chan="$(P)$(Bd)11"
 						clr=14
 						bclr=51
 					}
@@ -1942,7 +1942,7 @@ composite {
 						height=30
 					}
 					control {
-						chan="$(P)$(Bd22"
+						chan="$(P)$(Bd)22"
 						clr=14
 						bclr=51
 					}


### PR DESCRIPTION
Fixed two typos in EDIO24_module.adl for direction buttons.
