### PR TITLE
Fix EDIO24 auto_settings.req 

### DIFF
--- a/iocBoot/iocEDIO24/auto_settings.req
+++ b/iocBoot/iocEDIO24/auto_settings.req
@@ -1,1 +1,1 @@
-file "EDIO24_settings.req", P=EDIO24:
+file "EDIO24_settings.req", P=$(P)


### PR DESCRIPTION
Makes EDIO24 auto_settings.req work with different PREFIX in st.cmd