### PR TITLE
For E-TC, When setting open thermocouple detect use AI_CFG_OTD_MODE r…

### DIFF
--- a/measCompApp/src/drvMultiFunction.cpp
+++ b/measCompApp/src/drvMultiFunction.cpp
@@ -2099,8 +2099,8 @@ int MultiFunction::setOpenThermocoupleDetect(int addr, int value)
       status = cbSetConfig(BOARDINFO, boardNum_, addr, BIDETECTOPENTC, value);
     #else
       OtdMode mode = value ? OTD_ENABLED : OTD_DISABLED;
-      // TC-32 can only change open thermocouple detect for the entire device, not per-channel
-      if (boardFamily_ == USB_TC32) {
+      // TC-32 and E-TC can only change open thermocouple detect for the entire device, not per-channel
+      if (boardFamily_ == USB_TC32 || boardFamily_ == E_TC ) {
         int dev = 0;
         if (addr >= 32) dev = 1;
         status = ulAISetConfig(daqDeviceHandle_, AI_CFG_OTD_MODE, dev, mode);


### PR DESCRIPTION
@MarkRivers 

E-TC had the same issue that TC-32 has regarding the TC Open Detection. Please check this pull request to see whether you can merge it.

Or if you have another concern, please let me know.
