### PR TITLE
Fix win build

### DIFF
--- a/measCompApp/src/drvMultiFunction.cpp
+++ b/measCompApp/src/drvMultiFunction.cpp
@@ -1265,7 +1265,9 @@ MultiFunction::MultiFunction(const char *portName, const char *uniqueID, int max
   setIntegerParam(waveDigRun_, 0);
   setIntegerParam(waveGenRun_, 0);
   setDoubleParam(pollSleepMS_, 50.);
+  #ifdef linux
   aiInputMode_ = AI_SINGLE_ENDED;
+  #endif
   for (i=0; i<numTemperatureIn_; i++) {
     setIntegerParam(i, thermocoupleType_, TC_TYPE_J);
   }

--- a/measCompApp/src/measCompDiscover.cpp
+++ b/measCompApp/src/measCompDiscover.cpp
@@ -9,6 +9,7 @@
   #include "uldaq.h"
 #endif
 
+#include <epicsExport.h>
 #include <measCompDiscover.h>
 
 #define MAX_DEVICES 100


### PR DESCRIPTION
* Functions defined in measCompDiscover.h are prefixed with epicsShareFunc, but not actually exported.
* aiInputMode_ is only defined for linux at line 739.